### PR TITLE
fix(hacs): resolve model names reported in long form ("AquaClean Mera Classic")

### DIFF
--- a/custom_components/geberit_aquaclean/config_flow.py
+++ b/custom_components/geberit_aquaclean/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.loader import async_get_integration
 
 from .const import (
     DOMAIN,
-    ADV_DEVICE_TYPE_TO_MODEL,
+    resolve_device_model,
     CONF_DEVICE_ID,
     CONF_DEVICE_TYPE,
     CONF_ESPHOME_HOST,
@@ -543,7 +543,7 @@ class AquaCleanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     await asyncio.sleep(3.0)  # let BLE teardown propagate before coordinator first poll
                     data = {
                         CONF_DEVICE_ID: self._mac,
-                        CONF_DEVICE_TYPE: ADV_DEVICE_TYPE_TO_MODEL.get(self._adv_device_type_str),
+                        CONF_DEVICE_TYPE: resolve_device_model(self._adv_device_type_str),
                         CONF_ESPHOME_HOST: self._esphome_host,
                         CONF_ESPHOME_PORT: self._esphome_port,
                         CONF_NOISE_PSK: self._noise_psk,

--- a/custom_components/geberit_aquaclean/const.py
+++ b/custom_components/geberit_aquaclean/const.py
@@ -76,6 +76,55 @@ PROC82_DESCRIPTION_TO_MODEL: dict = {
     "AcCamaTestset":       "cama_testset",
 }
 
+# ── Model-name resolution ─────────────────────────────────────────────────
+# Devices do not agree on how to spell their own model. Observed so far:
+#
+#   proc 0x82 description  "AcMeraClassic"           (short form)
+#   proc 0x82 description  "AquaClean Mera Classic"  (long form, RS30.0 TS206)
+#   BLE advertisement      "Geberit Mera Classic"
+#
+# The two tables above only cover the exact spellings seen when they were
+# written, and a miss is silent: the model stays unknown and get_feature_sets()
+# falls back to _FS_FULL, so every model's entities are created.
+#
+# normalize_model_name() reduces any of these to a comparable key by
+# lower-casing, dropping non-alphanumerics and stripping the vendor/product
+# prefixes — all three examples above collapse to "meraclassic", which is the
+# model key "mera_classic" without its underscore.
+_MODEL_NAME_PREFIXES = ("geberit", "aquaclean", "ac")
+
+
+def normalize_model_name(raw: str | None) -> str:
+    """Reduce a device-reported model string to a comparable key."""
+    key = "".join(ch for ch in (raw or "").lower() if ch.isalnum())
+    for prefix in _MODEL_NAME_PREFIXES:
+        if key.startswith(prefix) and len(key) > len(prefix):
+            key = key[len(prefix):]
+    return key
+
+
+# Normalized spelling → model key, derived from the model table itself so a new
+# model only has to be added in one place.
+MODEL_BY_NORMALIZED_NAME: dict = {
+    normalize_model_name(model_key): model_key
+    for model_key in DEVICE_MODEL_FEATURE_SETS
+}
+
+
+def resolve_device_model(raw: str | None) -> str | None:
+    """Map a device-reported model string to a model key, or None if unknown.
+
+    Tries the exact tables first so existing behaviour is unchanged, then falls
+    back to the normalized lookup for spellings the tables do not list.
+    """
+    if not raw:
+        return None
+    return (
+        PROC82_DESCRIPTION_TO_MODEL.get(raw)
+        or ADV_DEVICE_TYPE_TO_MODEL.get(raw)
+        or MODEL_BY_NORMALIZED_NAME.get(normalize_model_name(raw))
+    )
+
 
 # ── Alba DpId coverage ────────────────────────────────────────────────────────
 # DpIds that have at least one wired HA entity (sensor, binary_sensor, number,

--- a/custom_components/geberit_aquaclean/coordinator.py
+++ b/custom_components/geberit_aquaclean/coordinator.py
@@ -25,7 +25,7 @@ from .const import (
     CONF_USE_HA_BLUETOOTH,
     DEFAULT_ESPHOME_PORT,
     DEFAULT_POLL_INTERVAL,
-    PROC82_DESCRIPTION_TO_MODEL,
+    resolve_device_model,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -578,10 +578,17 @@ class AquaCleanCoordinator(DataUpdateCoordinator):
                 if self._device_type == "alba":
                     self._device_model = "alba"
                 elif desc:
-                    self._device_model = PROC82_DESCRIPTION_TO_MODEL.get(desc)
+                    self._device_model = resolve_device_model(desc)
                     if self._device_model:
                         _LOGGER.info(
                             "Device model identified via proc 0x82: %s → %s", desc, self._device_model
+                        )
+                    else:
+                        _LOGGER.warning(
+                            "Unknown device model description %r — falling back to creating "
+                            "the entities of every model. Please report this string at "
+                            "https://github.com/jens62/geberit-aquaclean/issues so it can be mapped.",
+                            desc,
                         )
                 # Persist discovered model back to config entry so entity sets are correct
                 # on the next HA restart (avoids the full-entity fallback for manual-MAC installs).

--- a/tests/test_device_model_resolution.py
+++ b/tests/test_device_model_resolution.py
@@ -1,0 +1,111 @@
+"""Tests for device model-name resolution in the HA integration.
+
+No BLE hardware and no Home Assistant required — const.py has no imports, so
+it is loaded straight from its file path.
+
+Covers the three spellings devices use for their own model:
+    proc 0x82 description   "AcMeraClassic"           (short form)
+    proc 0x82 description   "AquaClean Mera Classic"  (long form, RS30.0 TS206)
+    BLE advertisement       "Geberit Mera Classic"
+"""
+
+import importlib.util
+import os
+import sys
+
+_repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_const_path = os.path.join(
+    _repo_root, "custom_components", "geberit_aquaclean", "const.py"
+)
+
+_spec = importlib.util.spec_from_file_location("geberit_const", _const_path)
+const = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(const)
+
+failures: list[str] = []
+
+
+def check(label: str, got, expected) -> None:
+    if got == expected:
+        print(f"  ok    {label}")
+    else:
+        print(f"  FAIL  {label}: expected {expected!r}, got {got!r}")
+        failures.append(label)
+
+
+def test_every_model_has_a_unique_normalized_key() -> None:
+    print("normalized keys are unique:")
+    check(
+        f"{len(const.DEVICE_MODEL_FEATURE_SETS)} models -> "
+        f"{len(const.MODEL_BY_NORMALIZED_NAME)} keys",
+        len(const.MODEL_BY_NORMALIZED_NAME),
+        len(const.DEVICE_MODEL_FEATURE_SETS),
+    )
+
+
+def test_exact_tables_still_resolve() -> None:
+    """Backward compatibility: every spelling the old tables handled must still work."""
+    print("exact tables still resolve:")
+    for table in (const.PROC82_DESCRIPTION_TO_MODEL, const.ADV_DEVICE_TYPE_TO_MODEL):
+        for raw, expected in table.items():
+            check(repr(raw), const.resolve_device_model(raw), expected)
+
+
+def test_long_form_descriptions_resolve() -> None:
+    """The regression: firmware RS30.0 TS206 reports the long form."""
+    print("long-form spellings resolve:")
+    for raw, expected in [
+        ("AquaClean Mera Classic", "mera_classic"),  # observed on real hardware
+        ("AquaClean Mera Comfort", "mera_comfort"),
+        ("AquaClean Tuma Classic", "tuma_classic"),
+        ("AquaClean Sela", "sela"),
+        ("AquaClean Cama Testset", "cama_testset"),
+        ("Geberit AquaClean Mera Classic", "mera_classic"),
+        ("Geberit AquaClean Alba", "alba"),
+        ("  AquaClean Mera Classic  ", "mera_classic"),
+        ("AQUACLEAN MERA CLASSIC", "mera_classic"),
+    ]:
+        check(repr(raw), const.resolve_device_model(raw), expected)
+
+
+def test_unknown_input_stays_unknown() -> None:
+    """No false positives — an unmapped model must not silently pick a wrong one."""
+    print("unknown input stays unknown:")
+    for raw in ["", None, "AcFuturisticModel9000", "Totally Unrelated", "Geberit"]:
+        check(repr(raw), const.resolve_device_model(raw), None)
+
+
+def test_unknown_model_still_gets_the_full_entity_set() -> None:
+    """get_feature_sets keeps its documented fallback."""
+    print("unknown model falls back to the full feature set:")
+    check(
+        "get_feature_sets(None)",
+        const.get_feature_sets(None),
+        const.get_feature_sets("definitely_not_a_model"),
+    )
+
+
+def test_mera_classic_excludes_comfort_only_features() -> None:
+    """The point of the fix: a resolved Mera Classic must not get Comfort entities."""
+    print("mera_classic excludes Comfort/Alba-only features:")
+    fs = const.get_feature_sets(const.resolve_device_model("AquaClean Mera Classic"))
+    for feature in (
+        const.FS_MERA_COMFORT_ONLY,
+        const.FS_WITH_SEAT_HEATER,
+        const.FS_WITH_WATER_HEATER,
+        const.FS_ALBA_ONLY,
+        const.FS_SELA_ONLY,
+    ):
+        check(f"{feature} not in feature sets", feature in fs, False)
+    check(const.FS_WITH_ODOUR_EXTRACTION, const.FS_WITH_ODOUR_EXTRACTION in fs, True)
+
+
+if __name__ == "__main__":
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            fn()
+    print()
+    if failures:
+        print(f"{len(failures)} failure(s): {failures}")
+        sys.exit(1)
+    print("all checks passed")


### PR DESCRIPTION
## The problem

On a **Mera Classic, firmware RS30.0 TS206**, the integration creates the entities of *every* model — 149 in total. About 50 never receive a value, and ~19 belong to hardware the Classic does not have. A few of those report plausible-looking values for absent hardware, e.g. `number.…_wc_seat_heat = 3.0` on a device without seat heating — easy to mistake for a real reading.

## Root cause

The device reports its model via proc 0x82 `description` as:

```
AquaClean Mera Classic
```

`PROC82_DESCRIPTION_TO_MODEL` only lists the short form `AcMeraClassic`. The lookup misses → `_device_model` stays `None` → it is never persisted to the config entry (`"device_type": null`) → `get_feature_sets()` falls back to `_FS_FULL`.

The miss is **silent** — there is no log line, so the only symptom is the entity count. This should affect every manual-MAC-entry install; devices discovered via advertisement go through `ADV_DEVICE_TYPE_TO_MODEL`, which uses a third spelling again (`Geberit Mera Classic`).

Evidence from the affected instance: `sensor.…_model` (the raw `description`, passed through unchanged by `AquaCleanClient`) reads `AquaClean Mera Classic`, and the config entry has `"device_type": null`.

## The fix

`normalize_model_name()` + `resolve_device_model()` in `const.py`. The normalizer lower-cases, drops non-alphanumerics and strips the vendor/product prefixes, so all three known spellings collapse onto the model key:

| reported | normalized |
|---|---|
| `AcMeraClassic` | `meraclassic` |
| `AquaClean Mera Classic` | `meraclassic` |
| `Geberit Mera Classic` | `meraclassic` |

Deliberate choices:

- **Exact tables are tried first**, normalized lookup only as a fallback → behaviour for every spelling that already worked is bit-for-bit unchanged.
- **The normalized table is derived from `DEVICE_MODEL_FEATURE_SETS`**, so adding a model still means touching one place only.
- **An unmapped description now logs a warning** naming the string, so the next unknown spelling surfaces instead of silently inflating the entity list.
- Both call sites (`coordinator.py` proc-0x82 path, `config_flow.py` advertisement path) use the same resolver.

## Tests

`tests/test_device_model_resolution.py` — standalone, no HA and no BLE needed (`const.py` has no imports, so it is loaded from its file path), matching the style of the existing test scripts. Covers:

- normalized keys are unique across all 9 models
- **all 17 spellings from both existing tables still resolve** (regression guard)
- the long form resolves, including mixed case, extra whitespace and a `Geberit AquaClean …` double prefix
- unknown/empty input still returns `None` — no false positives
- `get_feature_sets()` keeps its `_FS_FULL` fallback for unknown models
- a resolved Mera Classic no longer gets `MERA_COMFORT_ONLY`, `WITH_SEAT_HEATER`, `WITH_WATER_HEATER`, `ALBA_ONLY` or `SELA_ONLY` — while keeping `WITH_ODOUR_EXTRACTION`

```
$ python tests/test_device_model_resolution.py
all checks passed
```

## Notes

- Verified against `3.1.3b1`; the affected instance runs `3.1.2`.
- I only have one device, so the long-form spellings for models other than Mera Classic are inferred from the pattern, not observed. If Geberit is inconsistent there, the warning added in this PR will surface it.
- Existing installs that already hit this keep their inflated entity set until the model is re-detected, since `device_type` is only refined while it is `None` — that path is untouched here.
