### PR TITLE
fix: route MQTT control commands through ApiMode in on-demand mode

### DIFF
--- a/aquaclean_console_app/main.py
+++ b/aquaclean_console_app/main.py
@@ -594,8 +594,10 @@ _COMMON_SETTING_RANGES = {
 
 class ServiceMode:
     def __init__(self, mqtt_enabled=True, shutdown_event: asyncio.Event | None = None,
-                 firmware_version_ready_event: asyncio.Event | None = None):
+                 firmware_version_ready_event: asyncio.Event | None = None,
+                 register_direct_mqtt_handlers: bool = True):
         self.client = None
+        self._register_direct_mqtt_handlers = register_direct_mqtt_handlers
         self.mqtt_initialized_wait_queue = Queue()
         self.device_state = {
             "is_user_sitting": None,
@@ -686,11 +688,13 @@ class ServiceMode:
             interval = 2.5
         self.device_state["poll_interval"] = interval
 
-        # Subscribe MQTT handlers once — handlers reference self.client
-        # which is updated each iteration of the recovery loop below
-        self.mqtt_service.ToggleLidPosition += self.on_toggle_lid_message
-        self.mqtt_service.ResetFilterCounter += self.on_reset_filter_counter_message
-        self.mqtt_service.Connect += self.request_reconnect
+        # Standalone ServiceMode owns the legacy direct handlers. When embedded
+        # in ApiMode, ApiMode owns MQTT routing so the configured BLE connection
+        # mode is respected for every command and connect request.
+        if self._register_direct_mqtt_handlers:
+            self.mqtt_service.ToggleLidPosition += self.on_toggle_lid_message
+            self.mqtt_service.ResetFilterCounter += self.on_reset_filter_counter_message
+            self.mqtt_service.Connect += self.request_reconnect
 
         # Clear stale retained messages and publish initial status
         await self._clear_stale_retained_topics()
@@ -1684,8 +1688,12 @@ class ApiMode:
         self._poll_stats = _PollStats()
 
         # Always create ServiceMode so ble_connection can be toggled at runtime.
-        self.service = ServiceMode(mqtt_enabled=mqtt_enabled, shutdown_event=self._shutdown_event,
-                                   firmware_version_ready_event=self._firmware_version_ready)
+        self.service = ServiceMode(
+            mqtt_enabled=mqtt_enabled,
+            shutdown_event=self._shutdown_event,
+            firmware_version_ready_event=self._firmware_version_ready,
+            register_direct_mqtt_handlers=False,
+        )
         self.service.device_state["ble_connection"] = self.ble_connection
         self.service.device_state["esphome_api_connection"] = self.esphome_api_connection
         self.service.device_state["poll_interval"]  = self._poll_interval
@@ -1731,6 +1739,7 @@ class ApiMode:
         # Wire MQTT inbound control topics → ApiMode handlers
         self.service.mqtt_service.SetProfileSetting      += self._on_mqtt_set_profile_setting
         self.service.mqtt_service.SetCommonSetting       += self._on_mqtt_set_common_setting
+        self.service.mqtt_service.ToggleLidPosition          += self._on_mqtt_toggle_lid
         self.service.mqtt_service.ToggleAnal                  += self._on_mqtt_toggle_anal
         self.service.mqtt_service.ToggleLadyShower            += self._on_mqtt_toggle_lady
         self.service.mqtt_service.ToggleDryer                 += self._on_mqtt_toggle_dryer
@@ -1752,6 +1761,8 @@ class ApiMode:
         self.service.mqtt_service.LidPositionOffsetSave       += self._on_mqtt_lid_offset_save
         self.service.mqtt_service.LidPositionOffsetIncrement  += self._on_mqtt_lid_offset_increment
         self.service.mqtt_service.LidPositionOffsetDecrement  += self._on_mqtt_lid_offset_decrement
+        self.service.mqtt_service.ResetFilterCounter          += self._on_mqtt_reset_filter_counter
+        self.service.mqtt_service.Connect                     += self._on_mqtt_connect
         self.service.mqtt_service.SetBleConnection       += self._on_mqtt_set_ble_connection
         self.service.mqtt_service.SetEsphomeApiConnection += self._on_mqtt_set_esphome_api_connection
         self.service.mqtt_service.SetPollInterval         += self._on_mqtt_set_poll_interval
@@ -1900,6 +1911,12 @@ class ApiMode:
         except Exception as e:
             logger.warning(f"MQTT set_common_setting({setting_id}, {value}) failed: {e}")
 
+    async def _on_mqtt_toggle_lid(self):
+        try:
+            await self.run_command("toggle-lid")
+        except Exception as e:
+            logger.warning(f"MQTT toggle-lid failed: {e}")
+
     async def _on_mqtt_toggle_anal(self):
         try:
             await self.run_command("toggle-anal")
@@ -2026,6 +2043,12 @@ class ApiMode:
         except Exception as e:
             logger.warning(f"MQTT lid-offset-decrement failed: {e}")
 
+    async def _on_mqtt_reset_filter_counter(self):
+        try:
+            await self.run_command("reset-filter-counter")
+        except Exception as e:
+            logger.warning(f"MQTT reset-filter-counter failed: {e}")
+
     async def _on_mqtt_set_ble_connection(self, value: str):
         try:
             await self.set_ble_connection(value)
@@ -2043,6 +2066,12 @@ class ApiMode:
             await self.set_poll_interval(value)
         except Exception as e:
             logger.warning(f"MQTT set_poll_interval({value}) failed: {e}")
+
+    async def _on_mqtt_connect(self):
+        try:
+            await self.do_connect()
+        except Exception as e:
+            logger.warning(f"MQTT connect failed: {e}")
 
     async def _on_mqtt_disconnect(self):
         try:

--- a/tests/test_mqtt_api_routing.py
+++ b/tests/test_mqtt_api_routing.py
@@ -1,0 +1,72 @@
+import ast
+from pathlib import Path
+
+
+MAIN_PATH = Path(__file__).resolve().parents[1] / "aquaclean_console_app" / "main.py"
+SOURCE = MAIN_PATH.read_text(encoding="utf-8")
+TREE = ast.parse(SOURCE)
+
+
+def _class(name: str) -> ast.ClassDef:
+    return next(node for node in TREE.body if isinstance(node, ast.ClassDef) and node.name == name)
+
+
+def _method(class_name: str, method_name: str) -> ast.AsyncFunctionDef | ast.FunctionDef:
+    cls = _class(class_name)
+    return next(
+        node
+        for node in cls.body
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == method_name
+    )
+
+
+def _source(node: ast.AST) -> str:
+    return ast.get_source_segment(SOURCE, node) or ""
+
+
+def test_service_mode_direct_handlers_can_be_disabled_for_api_mode():
+    init = _method("ServiceMode", "__init__")
+    assert "register_direct_mqtt_handlers" in [arg.arg for arg in init.args.args]
+    assert isinstance(init.args.defaults[-1], ast.Constant)
+    assert init.args.defaults[-1].value is True
+
+    run = _method("ServiceMode", "run")
+    run_source = _source(run)
+    assert "if self._register_direct_mqtt_handlers:" in run_source
+    assert "self.mqtt_service.ToggleLidPosition += self.on_toggle_lid_message" in run_source
+    assert "self.mqtt_service.ResetFilterCounter += self.on_reset_filter_counter_message" in run_source
+    assert "self.mqtt_service.Connect += self.request_reconnect" in run_source
+
+
+def test_api_mode_disables_direct_handlers_on_embedded_service_mode():
+    init = _method("ApiMode", "__init__")
+    service_call = next(
+        node
+        for node in ast.walk(init)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "ServiceMode"
+    )
+    keyword = next(kw for kw in service_call.keywords if kw.arg == "register_direct_mqtt_handlers")
+    assert isinstance(keyword.value, ast.Constant)
+    assert keyword.value.value is False
+
+
+def test_api_mode_wires_direct_service_events_through_api_mode():
+    run_source = _source(_method("ApiMode", "run"))
+    assert (
+        "self.service.mqtt_service.ToggleLidPosition          += self._on_mqtt_toggle_lid"
+        in run_source
+    )
+    assert (
+        "self.service.mqtt_service.ResetFilterCounter          += self._on_mqtt_reset_filter_counter"
+        in run_source
+    )
+    assert "self.service.mqtt_service.Connect                     += self._on_mqtt_connect" in run_source
+
+
+def test_api_mode_handlers_use_run_command_router():
+    toggle_source = _source(_method("ApiMode", "_on_mqtt_toggle_lid"))
+    reset_source = _source(_method("ApiMode", "_on_mqtt_reset_filter_counter"))
+    connect_source = _source(_method("ApiMode", "_on_mqtt_connect"))
+    assert 'await self.run_command("toggle-lid")' in toggle_source
+    assert 'await self.run_command("reset-filter-counter")' in reset_source
+    assert "await self.do_connect()" in connect_source


### PR DESCRIPTION
Fixes #41

## Summary

This fixes MQTT control routing when the bridge runs in `ApiMode` with `ble_connection=on-demand`.

The concrete failure reported in #41 was `toggleLid`: the MQTT command was handled directly by `ServiceMode`, where no persistent client exists in on-demand mode, resulting in:

```text
'NoneType' object has no attribute 'toggle_lid_position'