### PR TITLE
fix(Mera): split GetSystemParameterList polling to preserve filter status request

### DIFF
--- a/aquaclean_console_app/aquaclean_core/Api/CallClasses/GetFilterStatus.py
+++ b/aquaclean_console_app/aquaclean_core/Api/CallClasses/GetFilterStatus.py
@@ -7,10 +7,10 @@ from aquaclean_console_app.aquaclean_core.Api.Attributes.ApiCallAttribute import
 
 
 # All "get list" procedures use a fixed 13-byte payload: 1 count byte + up to 12
-# ID bytes, zero-padded to 13.  The device rejects shorter payloads with 0xF7.
-# WARNING: the iPhone sends 12 IDs [0,1,2,3,4,5,6,7,4(dup),8,9,10] but the device
-# times out on that payload (confirmed: aquaclean-f2a96f1-TRACE-no-filter-data.log).
-# Use 8 IDs only — confirmed working in aquaclean-latest-TRACE-filter-works.log.
+# ID bytes, zero-padded to 13.  The bridge requests eight filter-status IDs here.
+# Keeping meaningful list content within the first transport frame also matches the
+# validated RS30.0 TS206 interoperability rule documented in
+# docs/developer/getfilterstatus-getspl-ordering.md.
 _FILTER_PAYLOAD = bytes([
     0x08,                                                        # count = 8
     0x00, 0x01, 0x02, 0x03, 0x07, 0x08, 0x09, 0x0a,           # IDs 0,1,2,3,7,8,9,10

--- a/aquaclean_console_app/aquaclean_core/Clients/AquaCleanClient.py
+++ b/aquaclean_console_app/aquaclean_core/Clients/AquaCleanClient.py
@@ -13,20 +13,24 @@ from aquaclean_console_app.myEvent import myEvent
 
 logger = logging.getLogger(__name__)
 
-# GetSystemParameterList (proc 0x0D) indices valid for AquaClean Mera Comfort.
-# Indices 0–7 are supported by all standard AquaClean device variants.
-# Indices 8–14 are device-variant specific:
-#   8  = StateSprayCalibration — not valid for Mera Comfort
-#   9  = StateOrientationLight — AcSela only, not valid for Mera Comfort
-#   10 = StateDraining         — AcCama/AcCamaTestset only, not valid for Mera Comfort
-#   12 = LidOffsetPosition     — Mera Comfort only, requires firmware ≥ RS25
-#   13 = ShowerArmOffsetPosition — Mera Comfort, safe (confirmed from OTA capture 2026-06-01)
-# Sending unsupported indices leaves the device in a state where subsequent
-# GetFilterStatus (proc 0x59) calls time out until the device is power-cycled.
-# NOTE: if support for other device models (AcSela, AcCama, …) is added, a
-# per-model parameter list will be needed here — do not simply extend this list.
-# data_array indexing is POSITION-BASED (not SPL-index-based): data_array[8]=param12, data_array[9]=param13
-SPL_PARAMS_MERA_COMFORT = [0, 1, 2, 3, 4, 5, 6, 7, 12, 13]
+# GetSystemParameterList (proc 0x0D) indices used for AquaClean Mera Comfort.
+#
+# IMPORTANT — keep the primary and auxiliary queries split.
+#
+# On Mera firmware RS30.0 TS206, a single 10-parameter GetSPL request
+# [0,1,2,3,4,5,6,7,12,13] completes successfully and returns all values, but
+# leaves GetFilterStatus (proc 0x59) unresponsive until the WC is power-cycled.
+# The same semantic parameters are safe when requested as two batches:
+# [0..7] followed by [12,13].  This was reproduced directly in the M diagnostic
+# suite: the split sequence preserved 0x59, while the combined request wedged it.
+#
+# With the fixed 13-byte GetSPL payload, <=8 actual parameters keep all
+# non-padding request bytes inside WRITE_0; WRITE_1 contains only zero padding.
+#
+# NOTE: if support for other AquaClean models is added, use a per-model
+# parameter selection; do not extend either batch past the safe boundary.
+SPL_PARAMS_MERA_COMFORT_STATE = [0, 1, 2, 3, 4, 5, 6, 7]
+SPL_PARAMS_MERA_COMFORT_AUX = [12, 13]
 
 class AquaCleanClient(IAquaCleanClient):
     def __init__(self, bluetooth_connector):
@@ -98,15 +102,21 @@ class AquaCleanClient(IAquaCleanClient):
             await asyncio.sleep(interval)
 
     async def _state_changed_timer_elapsed(self):
-        """Poll live device state via GetSystemParameterList (proc 0x0D)."""
-        result = await self.base_client.get_system_parameter_list_async(SPL_PARAMS_MERA_COMFORT)
+        """Poll live device state via two safe GetSystemParameterList batches."""
+        state_result = await self.base_client.get_system_parameter_list_async(
+            SPL_PARAMS_MERA_COMFORT_STATE
+        )
+        aux_result = await self.base_client.get_system_parameter_list_async(
+            SPL_PARAMS_MERA_COMFORT_AUX
+        )
+
         device_state_changed_event_args = DeviceStateChangedEventArgs(
-            IsUserSitting=result.data_array[0] != 0,
-            IsAnalShowerRunning=result.data_array[3] != 0,  # param 3 confirmed = anal shower
-            IsLadyShowerRunning=result.data_array[2] != 0,
-            IsDryerRunning=result.data_array[1] != 0,  # param 1, dryer state unknown
-            LidOffsetPosition=result.data_array[8],       # SPL index 12, position 8
-            ShowerArmOffsetPosition=result.data_array[9], # SPL index 13, position 9
+            IsUserSitting=state_result.data_array[0] != 0,
+            IsAnalShowerRunning=state_result.data_array[3] != 0,  # param 3 confirmed = anal shower
+            IsLadyShowerRunning=state_result.data_array[2] != 0,
+            IsDryerRunning=state_result.data_array[1] != 0,  # param 1, dryer state unknown
+            LidOffsetPosition=aux_result.data_array[0],       # legacy field name; SPL index 12
+            ShowerArmOffsetPosition=aux_result.data_array[1], # legacy field name; SPL index 13
         )
 
         if self.last_device_state_changed_event_args is None:

--- a/aquaclean_console_app/main.py
+++ b/aquaclean_console_app/main.py
@@ -15,7 +15,7 @@ from aiorun import run, shutdown_waits_for
 
 from bleak import BleakScanner
 from bleak.exc import BleakError
-from aquaclean_console_app.aquaclean_core.Clients.AquaCleanClient                   import AquaCleanClient, SPL_PARAMS_MERA_COMFORT
+from aquaclean_console_app.aquaclean_core.Clients.AquaCleanClient                   import AquaCleanClient, SPL_PARAMS_MERA_COMFORT_STATE, SPL_PARAMS_MERA_COMFORT_AUX
 from aquaclean_console_app.aquaclean_core.Clients.AquaCleanBaseClient               import BLEPeripheralTimeoutError
 from aquaclean_console_app.aquaclean_core.IAquaCleanClient                          import IAquaCleanClient
 from aquaclean_console_app.aquaclean_core.AquaCleanClientFactory                    import AquaCleanClientFactory
@@ -2963,18 +2963,27 @@ class ApiMode:
             return
 
     async def _fetch_state(self, client, _skip_profile: bool = False):
-        result = await client.base_client.get_system_parameter_list_async(SPL_PARAMS_MERA_COMFORT)
+        # Keep real GetSPL parameters inside WRITE_0.  On RS30.0 TS206 the
+        # combined [0..7,12,13] request returns successfully but wedges
+        # GetFilterStatus (0x59) until the WC is power-cycled.
+        state_result = await client.base_client.get_system_parameter_list_async(
+            SPL_PARAMS_MERA_COMFORT_STATE
+        )
+        aux_result = await client.base_client.get_system_parameter_list_async(
+            SPL_PARAMS_MERA_COMFORT_AUX
+        )
+
         # Update device_state before _on_demand's finally fires so the
         # "disconnected" SSE broadcast carries fresh values.
-        self.service.device_state["is_user_sitting"]           = result.data_array[0] != 0
-        self.service.device_state["is_anal_shower_running"]    = result.data_array[3] != 0  # param 3 confirmed = anal shower
-        self.service.device_state["is_lady_shower_running"]    = result.data_array[2] != 0
-        self.service.device_state["is_dryer_running"]          = result.data_array[1] != 0  # param 1, dryer state unknown
-        self.service.device_state["last_error_code"]           = result.data_array[6]
-        self.service.device_state["lid_offset_position"]       = result.data_array[8]  # SPL index 12, position 8
-        self.service.device_state["shower_arm_offset_position"] = result.data_array[9]  # SPL index 13, position 9
-        self.service.device_state["descaling_state"]            = result.data_array[4]  # SPL index 4: 0=idle 1=preparing 2=waiting 3=running
-        self.service.device_state["descaling_duration_min"]     = result.data_array[5]  # SPL index 5: countdown minutes
+        self.service.device_state["is_user_sitting"]            = state_result.data_array[0] != 0
+        self.service.device_state["is_anal_shower_running"]     = state_result.data_array[3] != 0  # param 3 confirmed = anal shower
+        self.service.device_state["is_lady_shower_running"]     = state_result.data_array[2] != 0
+        self.service.device_state["is_dryer_running"]           = state_result.data_array[1] != 0  # param 1, dryer state unknown
+        self.service.device_state["last_error_code"]            = state_result.data_array[6]
+        self.service.device_state["lid_offset_position"]        = aux_result.data_array[0]  # legacy field name; SPL index 12
+        self.service.device_state["shower_arm_offset_position"] = aux_result.data_array[1]  # legacy field name; SPL index 13
+        self.service.device_state["descaling_state"]            = state_result.data_array[4]  # SPL index 4: 0=idle 1=preparing 2=waiting 3=running
+        self.service.device_state["descaling_duration_min"]     = state_result.data_array[5]  # SPL index 5: countdown minutes
         state = {
             "is_user_sitting":            self.service.device_state["is_user_sitting"],
             "is_anal_shower_running":     self.service.device_state["is_anal_shower_running"],
@@ -3000,8 +3009,8 @@ class ApiMode:
     async def _fetch_state_and_info(self, client):
         """Used for the first on-demand poll only: fetch state + identification in one BLE session."""
         ident = await client.base_client.get_device_identification_async(0)
-        # GetFilterStatus before GetSPL: read filter data while the device is in a clean state
-        # at the start of the session (no prior proc calls that could affect its response).
+        # Read filter status during the initial info poll. Ordering is no longer a
+        # workaround: split GetSPL polling was validated to preserve 0x59 on RS30.0 TS206.
         try:
             filter_status = await client.base_client.get_filter_status_async()
         except BLEPeripheralTimeoutError:
@@ -3009,7 +3018,7 @@ class ApiMode:
             filter_status = None
         state = await self._fetch_state(client, _skip_profile=True)
 
-        # Remaining identification calls (safe to do after GetSPL).
+        # Remaining identification calls.
         initial_op_date = await client.base_client.get_device_initial_operation_date()
         fw = await client.base_client.get_firmware_version_list_async()
 

--- a/docs/developer/getfilterstatus-getspl-ordering.md
+++ b/docs/developer/getfilterstatus-getspl-ordering.md
@@ -1,148 +1,145 @@
-# GetFilterStatus / GetSPL Ordering Investigation
+# GetFilterStatus / GetSystemParameterList investigation
 
-**Status: Root cause UNKNOWN (2026-04-17) — trigger source clarified 2026-04-19**
+**Status: production workaround validated — 2026-08-17**
 
-## Which disconnect leaves GetFilterStatus (0x59) stuck — confirmed 2026-04-19
+## Scope
 
-| Trigger | GetFilterStatus (0x59) stuck? |
-|---------|-------------------------------|
-| iPhone Geberit Home App connect + close | ✅ yes — requires power cycle |
-| Bridge connect + disconnect | ❌ **no** — confirmed by filter-probe.py |
+This document describes a reproducible behavior on the tested **Geberit AquaClean Mera**
+running **RS30.0 TS206**, using the bridge's current BLE transport (ESPHome proxy, ATT MTU 23).
 
-**The bridge does not cause the 0x59 stuck state.** Only iPhone App sessions trigger it.
-No unlock sequence for 0x59 is needed in the bridge — Fix 3 (non-fatal catch in `_fetch_info()`)
-is the correct strategy: the timeout is caught gracefully and polling continues normally.
+Do **not** assume that every AquaClean model or firmware revision behaves identically.
+A newer nRF52840 capture from another Mera firmware shows the iOS app using a larger
+GetSystemParameterList request without the same observed failure.
 
-**No programmatic unlock exists for 0x59 (confirmed 2026-04-19).**
-All of the following were tested via filter-probe.py on a post-iPhone-session stuck device — none worked:
-- 4×Proc_0x11 + 4×Proc_0x13 (subscribe_notifications_async)
-- proc 0x53 profile settings (11 IDs)
-- proc 0x51 common settings (7 IDs)
-- proc 0x0A profile settings iPhone init style (10 IDs)
+## Final finding
 
-Power cycle is the only recovery. filter-probe.py has no init sequence — it reports the
-timeout clearly so the user knows a power cycle is needed.
+`GetSystemParameterList` (proc `0x0D`) can complete successfully while still leaving the
+toilet in an internal state where subsequent `GetFilterStatus` (proc `0x59`) requests receive
+no data response.
 
----
+On RS30.0 TS206 the bridge can reproduce the failure when **meaningful GetSPL request bytes
+extend past the first transport frame into the continuation frame**.
 
----
+The important distinction is not the semantic identity of SPL parameters 12/13:
 
-## Problem
+- `GetSPL [12]` — safe
+- `GetSPL [13]` — safe
+- `GetSPL [12,13]` — safe
+- `GetSPL [0,1,2,3,4,5,6,7]` followed by `GetSPL [12,13]` — safe
+- `GetSPL [0,1,2,3,4,5,6,7,12,13]` in one request — GetSPL succeeds, then 0x59 becomes unresponsive
 
-In the current bridge (post-d5cf93e), `GetFilterStatus` (proc 0x59) times out after
-`GetSPL` (proc 0x0D) is called with the 12-param iPhone list `[0,1,2,3,4,5,6,7,4,8,9,10]`.
+The tested production workaround is therefore:
 
-The device ACKs the GetFilterStatus request normally but then sends no data frames for 5 s,
-resulting in `BLEPeripheralTimeoutError`.
-
----
-
-## Evidence Files
-
-| File | Role |
-|------|------|
-| `local-assets/geberit-aquaclean-logs/standalone/aquaclean-36844ec…-TRACE-with filter-data.log` | Working reference (8-param GetSPL) |
-| `local-assets/geberit-aquaclean-logs/standalone/aquaclean-7d0d821…-TRACE-no-filter-data.log` | Failing case (12-param GetSPL) |
-| `local-assets/Bluetooth-Logs/Stuhlgang-approaching-toilet-lid-opens-sitting-analshower-dryer-leaving-lid-closes.txt` | iPhone reference (12-param, always works) |
-
----
-
-## Confirmed Facts (from TRACE log comparison)
-
-| | Working (36844ec) | Failing (7d0d821) |
-|---|---|---|
-| GetSPL params sent | `[0,1,2,3,4,5,6,9]` (8 params) | `[0,1,2,3,4,5,6,7,4,8,9,10]` (12 params) |
-| GetSPL CONS content | all-zeros (params fit in FIRST) | `04 08 09 0a 00…` |
-| a_byte | 7 | 9 |
-| GetSPL response frames | 4 | 4 |
-| GetSPL ACK bitmap | `0F00000000000000` | `0F00000000000000` (identical) |
-| GetFilterStatus request | `1104ff0011987e0101590d08000102030708090a` | identical |
-| Device ACK for GetFilterStatus | `70000c0a010000000000000000b7090100000df2` | identical |
-| Device data response | 4 frames in ~20 ms | nothing for 5 s → timeout |
-
-**Key finding:** The bridge's consumption of the GetSPL response is bit-for-bit identical in
-both cases. No bridge-side consumption bug can explain the difference.
-
----
-
-## Confirmed Facts (from iPhone BLE log — Stuhlgang log, decoded via `tools/ble-decode.py`)
-
-- iPhone uses **identical** param list: `[0, 1, 2, 3, 4, 5, 6, 7, 4, 8, 9, 10]`
-- iPhone calls GetFilterStatus **59 ms** after GetSPL — no intermediate calls
-- GetFilterStatus succeeds **every time**, on the same BLE connection
-- Calls are on the same BLE connection (no disconnect between GetSPL and GetFilterStatus)
-
----
-
-## Disproved Hypotheses
-
-### ❌ "Params 8/9/10 break GetFilterStatus — device-side firmware behavior"
-
-**Disproved by iPhone log.** ⚠️ *Doubted by user before confirmed.*
-
-iPhone uses the same 12-param list including 8/9/10, and GetFilterStatus always succeeds.
-The device does not break GetFilterStatus merely from receiving params 8/9/10 in GetSPL.
-
-### ❌ "Bridge consumption of GetSPL response is wrong — bridge-side bug"
-
-**Disproved by TRACE log comparison.** Bridge sends identical ACK bitmap `0F00000000000000`,
-identical frame count (4), identical byte values in working and failing cases.
-
-### ❌ "3-frame vs 4-frame GetSPL response"
-
-**Wrong** — both logs show 4-frame GetSPL response.
-
----
-
-## Remaining Hypothesis (UNCONFIRMED)
-
-### 🔍 Intermediate calls between GetSPL and GetFilterStatus
-
-**Bridge sequence (failing):**
-1. GetSPL(12 params) → OK
-2. GetDeviceInitialOperationDate → OK
-3. GetFirmwareVersionList → OK
-4. GetFilterStatus → TIMEOUT
-
-**iPhone sequence (working):**
-1. GetSPL(12 params) → OK
-2. GetFilterStatus → OK (59 ms later, no intermediate calls)
-
-The bridge inserts two extra calls between GetSPL and GetFilterStatus. One of these may
-corrupt device state. **Not yet confirmed** which call is responsible or whether this is
-truly the cause.
-
-**How to test:** On a freshly power-cycled device, run:
-
-```bash
-python tools/getspl-filter-probe.py --order spl-first --trace --log-file /tmp/probe-spl-first.log
+```text
+GetSPL [0,1,2,3,4,5,6,7]
+GetSPL [12,13]
 ```
 
-The probe calls GetSPL then immediately GetFilterStatus with no intermediate calls — matching
-the iPhone sequence. If GetFilterStatus succeeds here, the intermediate-calls hypothesis is
-confirmed. If it still times out, the intermediate calls are not the cause.
+Both persistent and on-demand polling use this split.
 
----
+## Why the combined request is especially deceptive
 
-## Current Workaround (commit d5cf93e)
+The failing combined request is **not rejected**.
 
-`_fetch_state_and_info()` calls GetFilterStatus **before** GetSPL. This helps if the device
-state is clean when the session starts. Whether it fully resolves the issue across reconnects
-is uncertain — probe tests with filter-first also failed, but may have been run on a device
-already in broken state from a prior session.
+The toilet:
 
----
+1. accepts WRITE_0/FIRST;
+2. accepts WRITE_1/CONS;
+3. acknowledges the transport frames;
+4. returns a valid GetSPL result containing the requested values;
+5. only afterwards stops answering GetFilterStatus.
 
-## Why 36844ec Worked
+In the M-series A/B test the failing combined request returned all ten values, including the
+two values requested in the continuation part. The continuation frame was therefore not
+simply lost or ignored.
 
-Version 36844ec sent only 8 params to GetSPL because of a CONS frame zero-padding bug: the
-CONS byte count was always computed from `message.serialize()` without accounting for actual
-parameter count, so extra bytes were zero-padded. The device received `[0,1,2,3,4,5,6,9]`
-with a_byte=7. GetFilterStatus was then called after intermediate calls, and it succeeded.
+## Diagnostic evidence
 
-Since the same intermediate calls existed in 36844ec, the working behavior suggests that
-receiving only 8 (supported) params in GetSPL does not trigger whatever state the device
-enters when it subsequently refuses to respond to GetFilterStatus. The device's behavior
-after 8-param vs 12-param GetSPL is different — but params 8/9/10 alone are not the trigger
-(iPhone disproves that). The interaction between GetSPL param count and the intermediate calls
-is the most likely remaining explanation.
+| Test | GetSPL request / variation | Result for subsequent 0x59 |
+|---|---|---|
+| H1 | 8 real params `[0,1,2,3,4,5,6,4]` | PASS |
+| H2A/H2B | 9 params, ninth real byte `0x00` | PASS |
+| H3A | ninth real byte `0x04` in CONS | FAIL |
+| J1 | ninth real byte `0x08` in CONS | FAIL |
+| L1 | same known-failing request with 30 ms FIRST→CONS delay | FAIL |
+| M1 | `[12]` | PASS |
+| M2 | `[13]` | PASS |
+| M3 | `[12,13]` | PASS |
+| M4 | `[0..7]` then `[12,13]` | PASS |
+| M5 | `[0..7,12,13]` combined | FAIL |
+
+Additional findings:
+
+- a 10-second RPC-free wait after GetSPL does not recover 0x59;
+- BLE disconnect/reconnect does not recover it;
+- a fresh connector/client does not recover it;
+- restarting the ESPHome proxy does not recover it;
+- only a WC power cycle restored 0x59 in the reproduced stuck state;
+- WRITE_0 and WRITE_1 both use ATT Write Without Response;
+- adding up to 30 ms between FIRST and CONS did not fix the failure;
+- CONTROL acknowledgements showed the WC acknowledging both transport frames;
+- the GetSPL response parser's DTO field `a` is not a reliable record-count interpretation.
+
+## Disproved or superseded explanations
+
+The following earlier explanations should no longer be treated as the root cause:
+
+- "Only an iPhone session can trigger the stuck state."
+- "The bridge cannot trigger it."
+- "Parameters 12 and 13 are themselves invalid."
+- "A specific duplicate parameter 4 is the cause."
+- "The continuation frame is simply lost."
+- "The GATT write type is wrong."
+- "A small FIRST→CONS delay is all that is missing."
+- "Intermediate RPCs after GetSPL are required to trigger the failure."
+
+The bridge reproduced the failure directly and the M-series test isolated the combined request
+as the discriminator.
+
+## Production validation
+
+After deploying the split polling implementation, multiple normal on-demand polls completed
+successfully on RS30.0 TS206.
+
+A later explicit REST request to:
+
+```text
+GET /data/filter-status
+```
+
+also succeeded after those polls and returned valid filter data. This is the production
+confirmation that the split polling workaround preserves `GetFilterStatus`.
+
+## Recovery
+
+If the device is already in the reproduced stuck state, reconnecting the bridge is not enough.
+Power-cycle the WC once. After that, the split polling implementation avoids re-triggering the
+known failure in normal operation.
+
+## Implementation rule
+
+For the tested RS30.0 TS206 bridge path:
+
+> Keep each GetSystemParameterList request at **8 or fewer meaningful parameter IDs**.
+
+The fixed 13-byte request payload may still contain zero padding in the continuation area; that
+was safe in the tests. The dangerous condition observed here is meaningful/non-zero request
+content extending into CONS.
+
+This is an empirical interoperability rule for this firmware/transport combination, not a claim
+about the abstract protocol specification.
+
+## Separate semantic issue: SPL 12/13 labels
+
+The filter-status bug and the semantic naming of SPL 12/13 are separate issues.
+
+Current protocol documentation identifies:
+
+- SPL 12 = `UnpostedShowerCycles`
+- SPL 13 = `DaysUntilNextDescale`
+
+The bridge historically exposes the returned values through fields named
+`LidOffsetPosition` / `ShowerArmOffsetPosition`. Those external names are intentionally left
+unchanged by the filter-status fix to avoid silently breaking existing MQTT/FHEM consumers.
+
+The semantic cleanup remains tracked separately in `docs/roadmap.md`.

--- a/tests/test_split_spl_polling.py
+++ b/tests/test_split_spl_polling.py
@@ -1,0 +1,151 @@
+import ast
+from pathlib import Path
+
+
+CLIENT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "aquaclean_console_app"
+    / "aquaclean_core"
+    / "Clients"
+    / "AquaCleanClient.py"
+)
+SOURCE = CLIENT_PATH.read_text(encoding="utf-8")
+TREE = ast.parse(SOURCE)
+
+
+def _assignment_value(name: str):
+    for node in TREE.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    return ast.literal_eval(node.value)
+    raise AssertionError(f"assignment {name!r} not found")
+
+
+def _method_source(class_name: str, method_name: str) -> str:
+    cls = next(
+        node
+        for node in TREE.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    method = next(
+        node
+        for node in cls.body
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+        and node.name == method_name
+    )
+    return ast.get_source_segment(SOURCE, method) or ""
+
+
+def test_mera_spl_batches_stay_within_safe_boundary():
+    assert _assignment_value("SPL_PARAMS_MERA_COMFORT_STATE") == list(range(8))
+    assert _assignment_value("SPL_PARAMS_MERA_COMFORT_AUX") == [12, 13]
+    assert len(_assignment_value("SPL_PARAMS_MERA_COMFORT_STATE")) <= 8
+    assert len(_assignment_value("SPL_PARAMS_MERA_COMFORT_AUX")) <= 8
+
+
+def test_state_poll_uses_two_getspl_requests_and_maps_aux_from_second_result():
+    source = _method_source("AquaCleanClient", "_state_changed_timer_elapsed")
+
+    assert source.count("get_system_parameter_list_async(") == 2
+    assert "SPL_PARAMS_MERA_COMFORT_STATE" in source
+    assert "SPL_PARAMS_MERA_COMFORT_AUX" in source
+
+    assert "IsUserSitting=state_result.data_array[0] != 0" in source
+    assert "IsAnalShowerRunning=state_result.data_array[3] != 0" in source
+    assert "IsLadyShowerRunning=state_result.data_array[2] != 0" in source
+    assert "IsDryerRunning=state_result.data_array[1] != 0" in source
+
+    assert "LidOffsetPosition=aux_result.data_array[0]" in source
+    assert "ShowerArmOffsetPosition=aux_result.data_array[1]" in source
+
+    # Regression guard: never reintroduce the known-destructive combined batch.
+    assert "[0, 1, 2, 3, 4, 5, 6, 7, 12, 13]" not in source
+
+
+
+
+def test_main_does_not_import_removed_combined_spl_constant():
+    main_path = Path(__file__).resolve().parents[1] / "aquaclean_console_app" / "main.py"
+    main_source = main_path.read_text(encoding="utf-8")
+    main_tree = ast.parse(main_source)
+
+    ac_imports = [
+        node
+        for node in main_tree.body
+        if isinstance(node, ast.ImportFrom)
+        and node.module
+        == "aquaclean_console_app.aquaclean_core.Clients.AquaCleanClient"
+    ]
+    assert len(ac_imports) == 1
+    imported_names = {alias.name for alias in ac_imports[0].names}
+    assert "AquaCleanClient" in imported_names
+    assert "SPL_PARAMS_MERA_COMFORT" not in imported_names
+
+
+
+def test_ondemand_fetch_state_uses_same_safe_split():
+    main_path = Path(__file__).resolve().parents[1] / "aquaclean_console_app" / "main.py"
+    main_source = main_path.read_text(encoding="utf-8")
+    main_tree = ast.parse(main_source)
+
+    api_mode = next(
+        node for node in main_tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "ApiMode"
+    )
+    fetch_state = next(
+        node for node in api_mode.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "_fetch_state"
+    )
+    source = ast.get_source_segment(main_source, fetch_state) or ""
+
+    assert source.count("get_system_parameter_list_async(") == 2
+    assert "SPL_PARAMS_MERA_COMFORT_STATE" in source
+    assert "SPL_PARAMS_MERA_COMFORT_AUX" in source
+
+    assert 'state_result.data_array[0]' in source
+    assert 'state_result.data_array[1]' in source
+    assert 'state_result.data_array[2]' in source
+    assert 'state_result.data_array[3]' in source
+    assert 'state_result.data_array[4]' in source
+    assert 'state_result.data_array[5]' in source
+    assert 'state_result.data_array[6]' in source
+    assert 'aux_result.data_array[0]' in source
+    assert 'aux_result.data_array[1]' in source
+
+    assert "result.data_array[8]" not in source
+    assert "result.data_array[9]" not in source
+
+
+def test_diagnostic_runtime_shim_is_removed():
+    init_path = Path(__file__).resolve().parents[1] / "aquaclean_console_app" / "__init__.py"
+    assert init_path.read_text(encoding="utf-8") == ""
+
+
+def test_no_runtime_reference_to_removed_combined_spl_symbol():
+    repo = Path(__file__).resolve().parents[1]
+    offenders = []
+
+    for path in repo.rglob("*.py"):
+        # Ignore generated caches/virtual envs if present in a developer checkout.
+        if any(part in {".git", ".venv", "venv", "__pycache__"} for part in path.parts):
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name) and node.id == "SPL_PARAMS_MERA_COMFORT":
+                offenders.append(f"{path.relative_to(repo)}:{getattr(node, 'lineno', '?')}")
+            elif isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    if alias.name == "SPL_PARAMS_MERA_COMFORT":
+                        offenders.append(f"{path.relative_to(repo)}:{getattr(node, 'lineno', '?')}")
+
+    assert offenders == [], "stale SPL_PARAMS_MERA_COMFORT runtime refs: " + ", ".join(offenders)
+
+if __name__ == "__main__":
+    test_mera_spl_batches_stay_within_safe_boundary()
+    test_state_poll_uses_two_getspl_requests_and_maps_aux_from_second_result()
+    test_main_does_not_import_removed_combined_spl_constant()
+    test_ondemand_fetch_state_uses_same_safe_split()
+    test_diagnostic_runtime_shim_is_removed()
+    test_no_runtime_reference_to_removed_combined_spl_symbol()
+    print("split SPL regression checks: OK")


### PR DESCRIPTION
Fixes #42

## Summary

This fixes a reproducible `GetFilterStatus` (`0x59`) failure observed on an AquaClean Mera running firmware `RS30.0 TS206`.

A `GetSystemParameterList` (`GetSPL`, procedure `0x0D`) request whose meaningful parameter IDs extend from the FIRST frame into a CONS continuation frame can complete successfully and still leave the toilet in an internal state where subsequent `GetFilterStatus` calls no longer return a data response.

The previous Mera polling request used:

```text
[0,1,2,3,4,5,6,7,12,13]
```

which crosses that FIRST → CONS boundary.

The fix replaces it with two independent requests:

```text
[0,1,2,3,4,5,6,7]
[12,13]
```

This split was validated on the affected device and preserves subsequent `GetFilterStatus` responses.

## Reproduction / investigation result

The combined request:

```text
GetSPL [0,1,2,3,4,5,6,7,12,13]
```

is accepted and processed successfully:

- both transport frames are acknowledged;
- `GetSPL` returns a valid response;
- values corresponding to the continuation parameters are present in the response.

However, immediately afterwards:

```text
GetFilterStatus (0x59)
```

times out.

Once in that state, `GetFilterStatus` remained unresponsive after:

- waiting in the same BLE session;
- BLE disconnect/reconnect;
- creating a fresh connector/client;
- restarting the ESPHome BLE proxy.

A WC power cycle restored `GetFilterStatus`.

Additional boundary testing showed that the issue is not caused by parameters `12` or `13` themselves:

```text
[12]       -> safe
[13]       -> safe
[12,13]    -> safe
[0..7]     -> safe
```

and the following back-to-back split sequence is also safe:

```text
[0..7]
[12,13]
```

The reproducible trigger on the tested firmware is therefore meaningful GetSPL request content crossing from the FIRST frame into a CONS frame.

## Changes

### Split Mera GetSPL polling

Replace the previous combined Mera parameter list with two explicit batches:

```python
SPL_PARAMS_MERA_COMFORT_STATE = [0, 1, 2, 3, 4, 5, 6, 7]
SPL_PARAMS_MERA_COMFORT_AUX = [12, 13]
```

Both polling paths now use the same split:

- persistent `AquaCleanClient` polling;
- `ApiMode` / on-demand polling.

State values are mapped from the first result and the existing auxiliary/legacy fields from the second result.

### Preserve existing external fields

No MQTT, REST or state field names are changed by this PR.

The existing fields:

```text
LidOffsetPosition
ShowerArmOffsetPosition
```

remain unchanged for compatibility, even though the protocol documentation for SPL indices `12` and `13` suggests different semantics.

Resolving those legacy names is intentionally outside the scope of this fix.

### Regression coverage

`tests/test_split_spl_polling.py` verifies that:

- the state batch is `[0..7]`;
- the auxiliary batch is `[12,13]`;
- neither request exceeds the tested safe FIRST-frame boundary;
- persistent polling performs exactly two GetSPL requests;
- on-demand polling uses the same split;
- state and auxiliary mappings use the correct result;
- the old combined `[0,1,2,3,4,5,6,7,12,13]` request is not reintroduced;
- no stale runtime reference to the removed combined SPL constant remains.

Developer documentation was also updated with the reproduced trigger, recovery behavior and firmware/model scope.

## Validation

The split request was deployed on the affected Mera and used during normal production polling.

After multiple normal on-demand polling cycles, an explicit:

```text
GET /data/filter-status
```

still returned valid filter data, confirming that normal split GetSPL polling no longer leaves `GetFilterStatus` stuck.

The regression test also passes directly:

```text
python tests/test_split_spl_polling.py

split SPL regression checks: OK
```

## Firmware / model scope

This workaround is validated on the tested:

```text
AquaClean Mera
RS30.0 TS206
```

It should **not** be interpreted as a universal protocol rule that GetSPL requests may never contain more than eight parameters.

A capture from another Mera / newer firmware shows the official iOS app using a larger GetSPL request without the same observed `0x59` failure.

The `<= 8 meaningful parameter IDs per request` rule in this PR is therefore a conservative interoperability workaround for the affected/tested firmware.

Additional validation would be useful on:

- other Mera firmware revisions;
- other AquaClean variants/models;
- different BLE transport paths where applicable.

The investigation focused specifically on the reproducible `GetFilterStatus` failure. It did not exhaustively test every other RPC after entering the stuck state.

## Compatibility

This PR does not change:

- MQTT topics;
- REST endpoints;
- externally exposed state field names;
- command semantics;
- BLE framing implementation.

It only changes how the Mera System Parameter List is queried during polling.
