### PR TITLE
fix(deps): make aioesphomeapi an optional [esphome] extra (fixes #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ curl -fsSL https://api.github.com/repos/jens62/geberit-aquaclean/releases | grep
 ```bash
 python3 -m venv ~/venv
 ~/venv/bin/pip install --upgrade pip setuptools wheel
-~/venv/bin/pip install git+https://github.com/jens62/geberit-aquaclean.git@<version>
+~/venv/bin/pip install "geberit-aquaclean[esphome] @ git+https://github.com/jens62/geberit-aquaclean.git@<version>"
 ```
 
 **Upgrading an existing install** (preserves your `config.ini`, stops/restarts the service automatically):

--- a/operation_support/install.sh
+++ b/operation_support/install.sh
@@ -43,7 +43,7 @@ if [ "$_OS" != "Linux" ]; then
     echo "       Detected OS: ${_OS}"
     echo ""
     echo "       To install manually on any platform:"
-    echo "         pip install \"git+https://github.com/jens62/geberit-aquaclean.git@${VERSION}\""
+    echo "         pip install \"geberit-aquaclean[esphome] @ git+https://github.com/jens62/geberit-aquaclean.git@${VERSION}\""
     echo ""
     exit 1
 fi
@@ -61,7 +61,7 @@ if [ "$_HAS_APT" = "0" ] && [ ! -d "$VENV" ]; then
     echo "       re-run this script — the apt step is skipped once the venv exists."
     echo ""
     echo "       Or install manually:"
-    echo "         pip install \"git+https://github.com/jens62/geberit-aquaclean.git@${VERSION}\""
+    echo "         pip install \"geberit-aquaclean[esphome] @ git+https://github.com/jens62/geberit-aquaclean.git@${VERSION}\""
     echo ""
     exit 1
 fi
@@ -85,8 +85,11 @@ echo "==> Upgrading pip, setuptools, wheel..."
 "${VENV}/bin/pip" install --upgrade pip setuptools wheel
 
 echo "==> Installing aquaclean-bridge @ ${VERSION}..."
+# [esphome] extra pulls aioesphomeapi for the ESP32-Bluetooth-Proxy transport,
+# which the standalone bridge uses. HA installs without the extra (via manifest.json)
+# so it keeps its own Core-pinned aioesphomeapi — see pyproject.toml / issue #38.
 "${VENV}/bin/pip" install --force-reinstall \
-    "git+https://github.com/jens62/geberit-aquaclean.git@${VERSION}"
+    "geberit-aquaclean[esphome] @ git+https://github.com/jens62/geberit-aquaclean.git@${VERSION}"
 
 echo ""
 echo "==> Installed version:"

--- a/operation_support/update.sh
+++ b/operation_support/update.sh
@@ -56,8 +56,10 @@ if systemctl is-active --quiet aquaclean-bridge 2>/dev/null; then
 fi
 
 echo "==> Upgrading aquaclean-bridge to ${VERSION}..."
+# [esphome] extra: keep aioesphomeapi for the standalone ESP32-Bluetooth-Proxy transport
+# (HA installs without the extra via manifest.json). See pyproject.toml / issue #38.
 "${VENV}/bin/pip" install --quiet --force-reinstall \
-    "git+https://github.com/jens62/geberit-aquaclean.git@${VERSION}"
+    "geberit-aquaclean[esphome] @ git+https://github.com/jens62/geberit-aquaclean.git@${VERSION}"
 
 echo "==> Restoring config.ini..."
 cp "$BACKUP" "$CONFIG"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "bleak>=2.0.0",       # note: 2.1.x may slow BLE connect on RPi5 BCM4345C0 + BlueZ 5.84
                           # (2.0.0 = ~1.8 s, 2.1.1 = ~25 s); ESP32 proxy is unaffected.
                           # HA ships bleak 2.1.1 — upper bound removed to allow HACS installation.
-    "aioesphomeapi",
+    # aioesphomeapi is intentionally NOT a hard dependency: see [project.optional-dependencies].esphome.
     "aiorun",
     "fastapi",
     "uvicorn",
@@ -29,6 +29,18 @@ include = ["aquaclean_console_app*"]
 "aquaclean_console_app" = ["static/*", "config.ini"]
 
 [project.optional-dependencies]
+# aioesphomeapi is provided by Home Assistant Core (the `esphome` / `bleak_esphome`
+# integrations pin it, e.g. ==45.6.1). Declaring it as a hard runtime dependency lets
+# pip override that pin with the newest PyPI release, and on Python builds without
+# prebuilt wheels (e.g. cp314) forces a source rebuild that produces ABI-incompatible
+# Cython artifacts — breaking ALL Noise-encrypted ESPHome devices on the HA instance.
+# See issue #38. Inside HA the ESP32-Bluetooth-Proxy transport is not used (HA has its
+# own habluetooth stack), so the dependency is unnecessary there. Standalone / non-HA
+# users who want the ESPHome-proxy transport install it explicitly:
+#     pip install "geberit-aquaclean[esphome]"
+# All aioesphomeapi imports in the codebase are lazy (function-level), so the package
+# imports and runs fine without this extra when the ESPHome transport is not used.
+esphome = ["aioesphomeapi"]
 test = ["pytest", "pytest-asyncio"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Problem

Declaring `aioesphomeapi` as a hard runtime dependency in `pyproject.toml` breaks **every Noise-encrypted ESPHome device** on a Home Assistant instance that has this integration installed (issue #38).

### Root cause

- HA Core pins `aioesphomeapi` exactly via its `esphome` / `bleak_esphome` integrations (e.g. `==45.6.1`).
- This package requires `aioesphomeapi` **without a version constraint** and is installed from a **git URL**. So on `ha core rebuild` (and on every Core update that recreates the container), pip installs the **newest** PyPI release over Core's pin.
- On interpreters without prebuilt wheels (currently **cp314 / Python 3.14**), that unpinned install is **built from source**, producing ABI-incompatible Cython artifacts. The Noise frame-helper import then crashes:
  ```
  ValueError: aioesphomeapi.connection.APIConnection size changed, may indicate binary incompatibility. Expected 240 from C header, got 232 from PyObject
  ... UnhandledAPIConnectionError: Error while finishing connection: '__reduce_cython__'
  ```
  Because the failing path is the Noise handshake, **all Noise-encrypted ESPHome API devices go `unavailable`** while the devices themselves stay online. A `ha core rebuild` only recovers it until the next Core update reinstalls the unpinned version.

As noted in #38, pinning alone is insufficient (the git-URL install still rebuilds from source into a second binary of the same version). Not declaring the dependency for the HA path avoids both the version override **and** the source rebuild.

## Fix

`aioesphomeapi` is not needed **inside HA**: HA provides it, and in HA the ESP32-Bluetooth-Proxy transport (`ESPHomeAPIClient`) is not used — HA has its own `habluetooth` stack. So this moves it to an optional **`esphome` extra**:

- HA manifest install (`geberit-aquaclean @ git+...`, no extra) → no longer overrides Core's pinned `aioesphomeapi`.
- All `aioesphomeapi` imports in the codebase are already **lazy (function-level)**, so the package imports and runs fine without the extra when the ESPHome-proxy transport is not used.

## Standalone bridge is preserved

Standalone / non-HA users who use the ESP32-Bluetooth-Proxy transport still get `aioesphomeapi` — `operation_support/install.sh`, `operation_support/update.sh`, and the README now install `geberit-aquaclean[esphome]`.

## Changes
- `pyproject.toml`: move `aioesphomeapi` from `dependencies` to `optional-dependencies.esphome` (with explanatory comment).
- `operation_support/install.sh`, `operation_support/update.sh`: install with `[esphome]` extra.
- `README.md`: manual install uses `[esphome]` extra.

## Verified
- `pyproject.toml` parses; `aioesphomeapi` absent from base deps, present under `optional-dependencies.esphome`.
- Confirmed all `aioesphomeapi` imports are function-level (`grep`), so no import-time breakage without the extra.

Independent reproduction environment: HA OS 18.2 / RPi 5 (aarch64) / Core 2026.8.3 / Python 3.14.6, aquaclean 3.1.2 — full trace posted in #38.